### PR TITLE
Make storage package configurable

### DIFF
--- a/config.yml.dist
+++ b/config.yml.dist
@@ -6,17 +6,20 @@ server:
     host: {{ default .Env.PIGGYSTORE__SERVER_HOST "127.0.0.1" }}
     port: {{ default .Env.PIGGYSTORE__SERVER_PORT 5000 }}
     name: {{ default .Env.PIGGYSTORE__SERVER_NAME "localhost" }}
-redis:
-    host: localhost
-    port: 6379
-    database: 0
-s3:
-    host: s3.amazonaws.com
-    region: us-east-1
-    bucket: ~
-    secure: true
-    access_key: ~
-    secret_key: ~
-files:
-    download_url_expire_after: 5m
+storage:
+    users:
+        module: piggy_store.storage.users.redis_storage
+        params:
+            host: localhost
+            port: 6379
+            database: 0
+    files:
+        module: piggy_store.storage.files.s3_storage
+        params:
+            host: s3.amazonaws.com
+            region: us-east-1
+            bucket: ~
+            secure: true
+            access_key: ~
+            secret_key: ~
 

--- a/configs/templates/piggy-store.conf.tmpl
+++ b/configs/templates/piggy-store.conf.tmpl
@@ -9,17 +9,20 @@ server:
     host: {{ getv "/app/piggy/host" "0.0.0.0" }}
     port: {{ getv "/app/piggy/port" "5000" }}
     name: {{ getv "/app/piggy/name" "localhost" }}
-redis:
-    host: {{ getv "/app/redis/host" "user_db" }}
-    port: {{ getv "/app/redis/port" "6379" }}
-    database: {{ getv "/app/redis/db" "0" }}
-s3:
-    host:       {{ getv "/app/s3/host" "s3like.com:9000" }}
-    region:     {{ getv "/app/s3/region" "us-east-1" }}
-    bucket:     {{ getv "/app/s3/bucket" "piggy-store-bucket" }}
-    secure:     {{ getv "/app/s3/secure" }}
-    access_key: {{ getv "/app/s3/key/access" }}
-    secret_key: {{ getv "/app/s3/key/secret" }}
-files:
-    download_url_expire_after: 5m
-
+storage:
+    users:
+        module: piggy_store.storage.users.redis_storage
+        params:
+            host: {{ getv "/app/redis/host" "user_db" }}
+            port: {{ getv "/app/redis/port" "6379" }}
+            database: {{ getv "/app/redis/db" "0" }}
+    files:
+        module: piggy_store.storage.files.s3_storage
+        params:
+            host:       {{ getv "/app/s3/host" "s3like.com:9000" }}
+            region:     {{ getv "/app/s3/region" "us-east-1" }}
+            bucket:     {{ getv "/app/s3/bucket" "piggy-store-bucket" }}
+            secure:     {{ getv "/app/s3/secure" }}
+            access_key: {{ getv "/app/s3/key/access" }}
+            secret_key: {{ getv "/app/s3/key/secret" }}
+            download_url_expire_after: 5m

--- a/piggy-store.py
+++ b/piggy-store.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 
 import os
+from piggy_store.app import create_app
 from piggy_store.config import load as load_config
 
-# load the config before doing anything else
 config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'config.yml')
 config = load_config(config_path)
-
-from piggy_store.app import create_app
-
 application = create_app(config)
 
 if __name__ == "__main__":

--- a/piggy_store/config.py
+++ b/piggy_store/config.py
@@ -49,18 +49,24 @@ def load(config_path):
         config['uploads']['max_content_length']
     )
 
-    config['files']['download_url_expire_after'] = _time_delta_from_human_to_timedelta(
-        config['files']['download_url_expire_after']
-    )
-
     if not config.get('storage'):
         config['storage'] = {}
 
-    if not config['storage'].get('users'):
-        config['storage']['users'] = 'redis'
+    storage_users = config['storage'].setdefault('users', {})
+    if not storage_users.get('module'):
+        storage_users['module'] = 'piggy_store.storage.users.redis_storage'
 
-    if not config['storage'].get('files'):
-        config['storage']['files'] = 's3'
+
+    storage_files = config['storage'].setdefault('files', {})
+    if not storage_files.get('files'):
+        storage_files['module'] = 'piggy_store.storage.files.s3_storage'
+
+    if not storage_users.get('params'):
+        storage_users['params'] = {}
+
+    config['storage']['files']['params']['download_url_expire_after'] = _time_delta_from_human_to_timedelta(
+        config['storage']['files']['params'].get('download_url_expire_after', '1 day')
+    )
 
     return config
 

--- a/piggy_store/storage/files/__init__.py
+++ b/piggy_store/storage/files/__init__.py
@@ -1,18 +1,14 @@
-from piggy_store.storage.files.file_entity import FileDTO
+from importlib import import_module
 from piggy_store.config import config
+from piggy_store.storage.files.file_entity import FileDTO
 
-if config['storage']['files'] == 's3':
-    from piggy_store.storage.files.s3_storage import S3Storage
-    def access_file_storage(options):
-        if options['user_dir'] != 'admin$':
-            options['user_dir'] = 'users/' + options['user_dir']
-        storage = S3Storage(dict(
-            url_expire_after = config['files']['download_url_expire_after'],
-            **config['s3'],
-            **options
-        ))
-        storage.init()
-        return storage
-else:
-    raise NotImplementedError('No such file storage: ' + config['storage']['files'])
+def access_file_storage(user_dir):
+    file_storage_module = import_module(config['storage']['files']['module'])
 
+    if user_dir != 'admin$':
+        user_dir = 'users/' + user_dir
+
+    storage = file_storage_module.Storage(user_dir, config['storage']['files']['params'])
+    storage.init()
+
+    return storage

--- a/piggy_store/storage/files/s3_storage.py
+++ b/piggy_store/storage/files/s3_storage.py
@@ -6,16 +6,14 @@ from minio.error import ResponseError
 
 from piggy_store.exceptions import FileExistsError, FileDoesNotExistError
 from piggy_store.storage.files.file_entity import FileDTO
-from piggy_store.storage.files.storage import Storage
-from piggy_store.helper import hash_checksum
-from piggy_store.config import config
+from piggy_store.storage.files.storage import Storage as BaseStorage
 
-class S3Storage(Storage):
-    def __init__(self, options):
-        self.opts = options
+class Storage(BaseStorage):
+    def __init__(self, user_dir, options):
         self.client = None
-        self.user_dir = options['user_dir']
+        self.user_dir = user_dir
         self.bucket = options['bucket']
+        self.opts = options
 
     def init(self):
         self.client = Minio(
@@ -36,7 +34,7 @@ class S3Storage(Storage):
         return self.client.presigned_get_object(
             self.bucket,
             object_name,
-            self.opts['url_expire_after']
+            self.opts['download_url_expire_after']
         )
 
     def add_file(self, f):

--- a/piggy_store/storage/files/storage.py
+++ b/piggy_store/storage/files/storage.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 class Storage(metaclass=ABCMeta):
-    def init(self):
+    def init(self, user_dir, options):
         pass
 
     @abstractmethod

--- a/piggy_store/storage/users/__init__.py
+++ b/piggy_store/storage/users/__init__.py
@@ -1,9 +1,8 @@
+from importlib import import_module
+
 from piggy_store.storage.users.user_entity import User
 from piggy_store.config import config
 
-if config['storage']['users'] == 'redis':
-    from piggy_store.storage.users.redis_storage import RedisStorage
-    user_storage = RedisStorage()
-else:
-    raise NotImplementedError('No such user storage: ' + config['storage']['users'])
-
+def get_user_storage():
+    user_storage_module = import_module(config['storage']['users']['module'])
+    return user_storage_module.Storage(config['storage']['users']['params'])

--- a/piggy_store/storage/users/storage.py
+++ b/piggy_store/storage/users/storage.py
@@ -1,6 +1,14 @@
-class Storage:
+from abc import ABCMeta, abstractmethod
+
+class Storage(metaclass=ABCMeta):
+    @abstractmethod
+    def __init__(self, options):
+        raise NotImplementedError()
+
+    @abstractmethod
     def add_user(self, user):
         raise NotImplementedError()
 
+    @abstractmethod
     def find_user_by_username(self, username):
         raise NotImplementedError()

--- a/tests/config.tests.yml
+++ b/tests/config.tests.yml
@@ -8,20 +8,21 @@ server:
     host: '0.0.0.0'
     port: 5000
     name: localhost
-redis:
-    host: user_db
-    port: 6379
-    database: 0
 storage:
-    users: redis
-    files: s3
-s3:
-    host: s3like.com:9000
-    region: us-east-1
-    bucket: bucket-test
-    secure: false
-    access_key: test_s3_access_key
-    secret_key: test_s3_secret_key
-files:
-    download_url_expire_after: 5m
+    users:
+        module: piggy_store.storage.users.redis_storage
+        params:
+            host: user_db
+            port: 6379
+            database: 0
+    files:
+        module: piggy_store.storage.files.s3_storage
+        params:
+            host: s3like.com:9000
+            region: us-east-1
+            bucket: bucket-test
+            secure: false
+            access_key: test_s3_access_key
+            secret_key: test_s3_secret_key
+            download_url_expire_after: 5m
 


### PR DESCRIPTION
This refactoring, other than letting the user choose different packages
to administer users and files, remove the need to load the config module
before anything else.