### PR TITLE
Add a config to whitelist allowed users

### DIFF
--- a/piggy_store/config.py
+++ b/piggy_store/config.py
@@ -61,6 +61,7 @@ def _sanitize_config(config):
 
     config.setdefault('debug', False)
     config.setdefault('uploads', {})
+    config.setdefault('users_whitelist', [])
     config['uploads'].setdefault('max_content_length', '1M')
 
     try:
@@ -72,6 +73,7 @@ def _sanitize_config(config):
         config['server']['host']
         config['server']['port']
         config['server']['name']
+        config['users_whitelist']
         config['sentry']
         config['sentry']['dsn']
         config['storage']

--- a/piggy_store/exception_handlers.py
+++ b/piggy_store/exception_handlers.py
@@ -7,7 +7,8 @@ from piggy_store.exceptions import (
     PiggyStoreError,
     UserDoesNotExistError,
     MultipleFilesRemoveError,
-    ChallengeMismatchError
+    ChallengeMismatchError,
+    UserNotAllowedError
 )
 
 from piggy_store.controller import hateoas_new_user
@@ -71,7 +72,7 @@ def register_default_exceptions(app):
         app.register_error_handler(exc_class, handle_unhautorized_errors)
 
     # 403s
-    for exc_class in (ChallengeMismatchError, ):
+    for exc_class in (ChallengeMismatchError, UserNotAllowedError):
         app.register_error_handler(exc_class, handle_forbidden_errors)
 
     # 500 caused by errors in external communications

--- a/piggy_store/exceptions.py
+++ b/piggy_store/exceptions.py
@@ -99,3 +99,11 @@ class MultipleFilesRemoveError(PiggyStoreError):
                      error.error_code,
                      error.error_message) for f,
                     error in pairs_file_error)))
+
+
+class UserNotAllowedError(PiggyStoreError):
+    CODE = 1014
+    MESSAGE = 'The user is not allowed: {}'
+
+    def __init__(self, username):
+        super().__init__(self.CODE, self.MESSAGE.format(username))

--- a/piggy_store/storage/__init__.py
+++ b/piggy_store/storage/__init__.py
@@ -7,7 +7,8 @@ from piggy_store.storage.files import (
     compose_challenge_file_filename,
     parse_challenge_file_filename
 )
-
+from piggy_store.exceptions import UserNotAllowedError
+from piggy_store.config import config
 
 class EasyStorageABC(metaclass=ABCMeta):
     @abstractmethod
@@ -58,6 +59,9 @@ class EasyStorage(EasyStorageABC):
         admin_file_storage.remove_file(f)
 
     def add_user(self, user):
+        if config['users_whitelist'] and not user.username in config['users_whitelist']:
+            raise UserNotAllowedError(user.username)
+
         file_storage = access_admin_storage()
         filename = compose_challenge_file_filename(user.username, user.answer)
         challenge_file = file_storage.build_file(filename, dict(

--- a/tests/config.tests.yml
+++ b/tests/config.tests.yml
@@ -8,6 +8,7 @@ server:
     host: '0.0.0.0'
     port: 5000
     name: localhost
+users_whitelist: ['foo', 'foobar']
 storage:
     cache:
         module: piggy_store.storage.cache.redis_storage

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ def get_minimal_loadable_config():
             'port': 443,
             'name': '',
         },
+        'users_whitelist': [],
         'sentry': {
             'dsn':  ''
         },
@@ -87,6 +88,7 @@ def test_error_on_missing_keys(config_mod, required_key):
 @pytest.mark.parametrize('defaulted_key', [
     'debug',
     'uploads.max_content_length',
+    'users_whitelist'
 ])
 def test_config_keys_with_defaults(config_mod, defaulted_key):
     # remove a key and check that it comes back with a default value


### PR DESCRIPTION
If the configuration key `users_whitelist` is empty than every username
is allowed. If the key is not empty than it's a list containing the only
usernames that are allowed to create an account (existing users not present in the
configuration are unaffected).