### PR TITLE
Change strategy to check for write permissions

### DIFF
--- a/piggy_store/exceptions.py
+++ b/piggy_store/exceptions.py
@@ -117,7 +117,7 @@ class BucketDoesNotExistError(PiggyStoreError):
         super().__init__(self.CODE, self.MESSAGE.format(bucketname))
 
 
-class BucketPolicyError(PiggyStoreError):
+class BucketWriteError(PiggyStoreError):
     CODE = 1016
     MESSAGE = 'The configured bucket does not allow either upload or download'
 


### PR DESCRIPTION
The previous strategy was too naive and I can't take into account IAM rules, bucket policies and object ACL and figure out who wins: let's just try to write a file