### PR TITLE
Use server secret to generate the tokens seed

### DIFF
--- a/piggy_store/storage/cache/__init__.py
+++ b/piggy_store/storage/cache/__init__.py
@@ -12,5 +12,6 @@ def get_cache_storage():
 def get_token_storage():
     return AuthTokenStorage({
         **config['storage']['cache']['params'],
-        'timeout': config['auth_token_expire_after']
+        'timeout': config['auth_token_expire_after'],
+        'secret': config['secret']
     })


### PR DESCRIPTION
It let us:
- restart the server without invalidating the tokens
- have multiple servers that accept the same tokens

The salt has not been randomized because it's a single user use case and
the secret is random.